### PR TITLE
Update everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .nyc_outputs
 .nyc_output/*
+coverage

--- a/bin.js
+++ b/bin.js
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
-const cliOpts = require('cliclopts')
-const path = require('path')
-const minimist = require('minimist')
-const version = require('./package.json').version
-const gravatarFavicon = require('./index')
+import cliOpts from 'cliclopts'
+import path from 'path'
+import fs from 'fs/promises' // Use promises version of fs
+import minimist from 'minimist'
+import gravatarFavicon from './index.js'
+import { fileURLToPath } from 'url'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const data = await fs.readFile(path.resolve(dirname, './package.json'), 'utf-8')
+const { version } = JSON.parse(data)
 
 const allowedOptions = [
   {
@@ -52,7 +57,8 @@ const config = {}
 
 if (argv.config) {
   const configPath = path.resolve(process.cwd(), argv.config)
-  Object.assign(config, require(configPath))
+  const configImport = await import(configPath)
+  Object.assign(config, configImport.default)
   if (config.dest) {
     // allow relative path resolution from configPath
     config.dest = path.resolve(path.dirname(configPath), config.dest)

--- a/example-config.js
+++ b/example-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   email: 'bcomnes@gmail.com',
   dest: './out',
   faviconConfig: {
@@ -30,7 +30,7 @@ module.exports = {
       coast: false, // Create Opera Coast icon. `boolean` or `{ offset, background }`
       favicons: true, // Create regular favicons. `boolean`
       firefox: false, // Create Firefox OS icons. `boolean` or `{ offset, background }`
-      windows: true, // Create Windows 8 tile icons. `boolean` or `{ background }`
+      windows: false, // Create Windows 8 tile icons. `boolean` or `{ background }`
       yandex: false // Create Yandex browser icon. `boolean` or `{ background }`
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "gravatar-favicons",
   "version": "2.0.1",
   "description": "Generate every favicon from an email address's gravatar",
+  "type": "module",
   "main": "index.js",
   "bin": "./bin.js",
   "scripts": {
     "debug": "node --nolazy --inspect-brk=9229 node_modules/.bin/tape 'test.js' | tap-format-spec",
     "prepublishOnly": "git push && git push --tags && gh-release",
     "test": "run-s test:*",
-    "test:lint": "standard | snazzy",
-    "test:tape": "nyc tape 'test.js' | tap-format-spec",
-    "test:dependencies": "dependency-check package.json --missing --unused --no-dev",
+    "test:lint": "standard",
+    "test:node-test": "c8 node --test --test-reporter spec",
     "version": "run-s version:*",
     "version:changelog": "auto-changelog -p --template keepachangelog --breaking-pattern 'breaking'",
     "version:git": "git add CHANGELOG.md"
@@ -34,15 +34,19 @@
     "bl": "^6.0.0",
     "cliclopts": "^1.1.1",
     "concat-stream": "^2.0.0",
-    "favicons": "^6.2.0",
+    "favicons": "^7.1.4",
     "from2-string": "^1.1.0",
-    "gravatar-url": "^3.1.0",
+    "gravatar-url": "^4.0.1",
     "minimist": "^1.2.0",
-    "node-fetch": "^2.6.1",
+    "p-all": "^5.0.0",
     "pump": "^3.0.0",
-    "run-parallel-limit": "^1.0.4"
+    "undici": "^5.26.3"
   },
   "devDependencies": {
-    "@bret/toolbox": "^4.0.0"
+    "auto-changelog": "^2.4.0",
+    "c8": "^8.0.1",
+    "gh-release": "^7.0.2",
+    "npm-run-all2": "^6.1.1",
+    "standard": "^17.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,13 +1,24 @@
-const test = require('tape')
-const gravatarFavicons = require('.')
-const rimraf = require('rimraf')
+import test from 'node:test'
+import assert from 'node:assert'
+import gravatarFaviconsAsync from './index.js'
+import { promises as fs } from 'node:fs'
+import exampleConfig from './example-config.js'
 
-test('can generate favicons', t => {
-  const config = require('./example-config')
-  rimraf.sync(config.dest)
+test('can generate favicons', async () => {
+  const config = exampleConfig
 
-  gravatarFavicons(config, console.log, (err, results) => {
-    t.error(err, 'generate favicons without error')
-    t.end()
-  })
+  // Remove the directory recursively
+  try {
+    await fs.rm(config.dest, { recursive: true, force: true })
+  } catch (error) {
+    // Handle case where directory doesn't exist or other FS-related errors
+    console.warn(`Could not remove directory: ${error.message}`)
+  }
+
+  try {
+    await gravatarFaviconsAsync(config, console.log)
+    assert.ok(true, 'generate favicons without error')
+  } catch (err) {
+    assert.fail(`Test failed: ${err.message}`)
+  }
 })


### PR DESCRIPTION
- BREAKING CHANGE: Convert to esm only module. Sorry deps forced this.
- BREAKING CHANGE: Switch to promise based API. The old callback API is still exposed. See README.
- BREAKING CHANGE: Raised floor of supported node and npm.
- BREAKING CHANGE: Updated all deps.

The only main breaking change you need to handle is updating your config objects to esm, and switching to async await.